### PR TITLE
Ignore irrelevant PRs

### DIFF
--- a/src/get-changelog-data.js
+++ b/src/get-changelog-data.js
@@ -152,7 +152,7 @@ async function fetchPrs(octokit, {repo, owner, since}) {
 
     const result = new Map();
     for (const pr of data) {
-        if (!pr.merge_commit_sha) continue;
+        if (!pr.merge_commit_sha || !pr.merged_at || pr.merged_at < since) continue;
         result.set(pr.merge_commit_sha, pr);
     }
 


### PR DESCRIPTION
Ignore PRs that were closed without being merged, or were merged prior to the previous release. Sorting by 'updated' with a cutoff doesn't eliminate the latter because updates may happen post-merge.