### PR TITLE
Fix skip label

### DIFF
--- a/src/branch-permissions.js
+++ b/src/branch-permissions.js
@@ -1,7 +1,6 @@
 const parse = require('parse-github-url');
 const getRemoteUrl = require('../src/git-remote-url');
 const octokit = require('@octokit/rest')();
-const {execSync} = require('child_process');
 
 module.exports = async function ({target, source}) {
     const {owner, name: repo} = parse(await getRemoteUrl());

--- a/src/parse-and-categorize-changelog-entries.js
+++ b/src/parse-and-categorize-changelog-entries.js
@@ -29,7 +29,7 @@ module.exports = {
             let body;
             let matches = pr.body.match(/\<changelog\>(.*)<\/changelog>/);
             if (matches) {
-                body = matches[1]
+                body = matches[1];
             } else {
                 body = pr.title;
             }
@@ -83,13 +83,13 @@ module.exports = {
         for (const entry of entries) {
             let section = Object.values(sections).find((section) => {
                 return section.labels.includes(entry.label);
-            })
+            });
 
             if (!section) {
                 section = sections.unlabeled;
             }
 
-            section.entries.push(entry)
+            section.entries.push(entry);
         }
 
         return sections;

--- a/src/parse-and-categorize-changelog-entries.js
+++ b/src/parse-and-categorize-changelog-entries.js
@@ -7,6 +7,7 @@ const PR_LABELS = {
     performance: { name: 'performance :zap:' },
     workflow: { name: 'workflow :nail_care:' },
     testing: { name: 'testing :100:' },
+    skip: { name: 'skip changelog' },
 };
 
 module.exports = {

--- a/test/parse-and-categorize-changelog-entries.test.js
+++ b/test/parse-and-categorize-changelog-entries.test.js
@@ -40,8 +40,12 @@ const mockEntries = [
         body: "A changelog bug entry body",
         label: PR_LABELS.bug,
         pullRequest: {}
-    }
-]
+    },
+    {
+        body: "An unlabeled entry body",
+        pullRequest: {}
+    },
+];
 
 
 test('parseEntriesFromPullRequests returns entries', async function(t) {
@@ -79,5 +83,5 @@ test('categorizeEntries', async function(t) {
 
     t.equal(sections.improvements.entries.length, 2);
     t.equal(sections.bugs.entries.length, 1);
-    t.equal(sections.unlabeled.entries.length, 0);
+    t.equal(sections.unlabeled.entries.length, 1);
 });


### PR DESCRIPTION
Add missing mapping for github PR label "skip changelog". Also includes a few linting fixes and a better test for categorizing unlabeled PRs.