### PR TITLE
Add support for 'canonical' labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/github-release-tools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "engines": {
     "node": ">=8"
   },

--- a/src/parse-and-categorize-changelog-entries.js
+++ b/src/parse-and-categorize-changelog-entries.js
@@ -1,13 +1,13 @@
 // `name` maps to github PR label name fields
 const PR_LABELS = {
-    breaking: { name: 'breaking change :warning:' },
-    bug: { name: 'bug :beetle:' },
-    feature: { name: 'feature :green_apple:' },
-    docs: { name: 'docs :scroll:' },
-    performance: { name: 'performance :zap:' },
-    workflow: { name: 'workflow :nail_care:' },
-    testing: { name: 'testing :100:' },
-    skip: { name: 'skip changelog' },
+    breaking: { name: 'breaking change :warning:', canonical_name: 'breaking change' },
+    bug: { name: 'bug :beetle:', canonical_name: 'bug' },
+    feature: { name: 'feature :green_apple:', canonical_name: 'feature' },
+    docs: { name: 'docs :scroll:', canonical_name: 'docs' },
+    performance: { name: 'performance :zap:', canonical_name: 'performance' },
+    workflow: { name: 'workflow :nail_care:', canonical_name: 'build' },
+    testing: { name: 'testing :100:', canonical_name: 'testing' },
+    skip: { name: 'skip changelog', canonical_name: 'skip changelog' },
 };
 
 module.exports = {
@@ -21,7 +21,7 @@ module.exports = {
 
             let foundLabel;
             for (const label of Object.values(PR_LABELS)) {
-                if (labelNames.includes(label.name)) {
+                if (labelNames.includes(label.name) || labelNames.includes(label.canonical_name)) {
                     foundLabel = label;
                 }
             }

--- a/test/get-latest-release.test.js
+++ b/test/get-latest-release.test.js
@@ -12,5 +12,5 @@ test('getLatestRelease', async function(t) {
 
     const latest = await getLatestRelease(octokit, {repo, owner});
 
-    t.equal(latest, "v1.5.0", "Latest release version");
+    t.equal(latest, "v1.12.0", "Latest release version");
 });


### PR DESCRIPTION
So that changelog-draft script would support old format (with icons) and canonical PR labels.