### PR TITLE
Add more documentation to changelog-draft; change default branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,32 @@ Options:
 ```
 changelog-draft
 
-Generate a draft changelog entry using changes to master since the most recent
-release.
+Generate a draft changelog entry using changes to the default branch since the most recent
+release. This is done by scanning pull request descriptions for content between
+<changelog></changelog> tags. Below is an example of this format:
+
+`<changelog>Fixes an issue where something would crash.</changelog>`
+
+In addition, if a pull request is labeled with the following tags, the changelog entry 
+will fall under a markdown header associated with that tag's name:
+
+• breaking change ⚠️
+• bug 🐞
+• feature 🍏
+• docs 📜
+• performance ⚡️
+• workflow 💅
+• testing 💯
+• skip changelog
+
+Note: Pull requests with the "skip changelog" tag will not be included in 
+the generated changelog output.
 
 Options:
   --help          Show help                                            [boolean]
   --version       Show version number                                  [boolean]
   -b, --branch    the branch from which this release is being made
-                                                    [string] [default: "master"]
+                                                      [string] [default: "main"]
   -p, --previous  the previous release; defaults to the most recent vX.Y.Z tag
                                                                         [string]
   -f, --format    output format          [choices: "md", "json"] [default: "md"]
@@ -78,7 +96,7 @@ Copies branch protection permissions from one branch to another.
 
 Positionals:
   target  Branch to copy permissions to                                 [string]
-  source  Branch to copy permissions from           [string] [default: "master"]
+  source  Branch to copy permissions from             [string] [default: "main"]
 
 Options:
   --version  Show version number                                       [boolean]

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ release. This is done by scanning pull request descriptions for content between
 In addition, if a pull request is labeled with the following tags, the changelog entry 
 will fall under a markdown header associated with that tag's name:
 
-• breaking change ⚠️
-• bug 🐞
-• feature 🍏
-• docs 📜
-• performance ⚡️
-• workflow 💅
-• testing 💯
+• breaking change
+• bug
+• feature
+• docs
+• performance
+• workflow
+• testing
 • skip changelog
 
 Note: Pull requests with the "skip changelog" tag will not be included in 

--- a/bin/branch-permissions
+++ b/bin/branch-permissions
@@ -13,7 +13,7 @@ require('yargs')
         yargs.positional('source', {
             describe: 'Branch to copy permissions from',
             type: 'string',
-            default: 'master'
+            default: 'main'
         });
     }, require('../src/branch-permissions'))
     .help()

--- a/bin/changelog-draft
+++ b/bin/changelog-draft
@@ -5,13 +5,13 @@ const octokit = require('../src/octokit');
 const renderChangelogDraft = require('../src/changelog-draft');
 
 const description =  `\
-Generate a draft changelog entry using changes to master since the most recent release.`;
+Generate a draft changelog entry using changes to main since the most recent release.`;
 
 require('yargs').usage('$0', description, {
     'b': {
         describe: 'the branch from which this release is being made',
         alias: 'current',
-        default: 'master',
+        default: 'main',
         type: 'string'
     },
     'p': {


### PR DESCRIPTION
Adds more documentation to the `draft-changelog` script, and changes the default branch to `main` (reflecting the new default across Mapbox projects).

I'm not sure who this project's owner is, so I'm tagging @kkaefer since he's last edited these files and @alexshalamov who has also recently made contributions to this project.

As a side note, I'm not sure if there's something I should have done to get Travis to not fail, it looks like there is an authentication issue on CI?

---
`<changelog>The default branch used is now set to "main".</changelog>`