### PR TITLE
Migrate to circleci from travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,15 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ checksum "yarn.lock" }}
-      - run: yarn
+          name: Restore Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install Dependencies
+          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
       - save_cache:
-          key: v1-deps-{{ checksum "yarn.lock" }}
+          key: yarn-packages-{{ checksum "yarn.lock" }}
           paths: 
-            - node_modules  
+            - ~/.cache/yarn
       - run:
           name: Install mbx-ci
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,29 @@
 version: 2.1
-orbs:
-  node: circleci/node@5.0.3
 
 jobs:
   build_and_test:
-    executor: node/default
+    docker:
+      - image: cimg/node:9.0.0
     steps:
       - checkout
-      - node/install-packages:
-        pkg-manager: yarn
+      - restore_cache:
+        key: v1-deps-{{ checksum "package-lock.json" }}
+      - run: yarn
+      - save_cache:
+          key: v1-deps-{{ checksum "package-lock.json" }}
+          paths: 
+            - node_modules  
       - run:
           name: Install mbx-ci
           command: |
             curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci &&
             chmod 755 ./mbx-ci
       - run:
-          name: Authenticate mbx-ci and run tests
-          command: |
-            export GITHUB_TOKEN=$(./mbx-ci github reader token)
-            yarn test
+          name: Authenticate mbx-ci
+          command: export GITHUB_TOKEN=$(./mbx-ci github reader token)
+      - run:
+          name: Run tests
+          command: yarn test
 
 workflows:
   test_github_release_tools:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,25 @@
 version: 2.1
 orbs:
   node: circleci/node@5.0.3
+
 jobs:
-  build:
-    docker:
-      - image: 'cimg/base:stable'
+  build_and_test:
+    executor: node/default
     steps:
       - checkout
       - >-
         curl -Ls
         https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64
         > mbx-ci && chmod 755 ./mbx-ci
+      - node/install-packages:
+        pkg-manager: yarn
       - run:
           name: Authenticate mbx-ci and run tests
           command: |
             export GITHUB_TOKEN=$(./mbx-ci github reader token)
             yarn test
+
 workflows:
-  run-npm-command:
+  test_github_release_tools:
     jobs:
-      - node/run:
-        yarn-run: build
+      - build_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           command: |
             curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci &&
             chmod 755 ./mbx-ci
+            export export MBX_CI_DOMAIN=o619qyc20d.execute-api.us-east-1.amazonaws.com
             export GITHUB_TOKEN=$(./mbx-ci github reader token)
             yarn test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,10 @@ jobs:
             curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci &&
             chmod 755 ./mbx-ci
       - run:
-          name: Authenticate mbx-ci
-          command: export GITHUB_TOKEN=$(./mbx-ci github reader token)
-      - run:
-          name: Run tests
-          command: yarn test
+          name: Authenticate mbx-ci and run tests
+          command: |
+          export GITHUB_TOKEN=$(./mbx-ci github reader token)
+          yarn test
 
 workflows:
   test_github_release_tools:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,20 @@
 version: 2.1
-
 orbs:
   node: circleci/node@5.0.3
-
 jobs:
   build:
     docker:
-      - image: cimg/base:stable
+      - image: 'cimg/base:stable'
     steps:
-      - curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
+      - >-
+        curl -Ls
+        https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64
+        > mbx-ci && chmod 755 ./mbx-ci
       - run:
         name: Authenticate mbx-ci and run tests
         command: |
           export GITHUB_TOKEN=$(./mbx-ci github reader token)
           yarn test
-
 workflows:
   run-npm-command:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,7 @@ jobs:
     executor: node/default
     steps:
       - checkout
-      - >-
-        curl -Ls
-        https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64
-        > mbx-ci && chmod 755 ./mbx-ci
+      - curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
       - node/install-packages:
         pkg-manager: yarn
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ orbs:
 
 jobs:
   build:
+    docker:
+      - image: cimg/base:stable
     steps:
       - curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,13 @@ jobs:
     executor: node/default
     steps:
       - checkout
-      - curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
       - node/install-packages:
         pkg-manager: yarn
+      - run:
+          name: Install mbx-ci
+          command: |
+            curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci &&
+            chmod 755 ./mbx-ci
       - run:
           name: Authenticate mbx-ci and run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ checksum "package-lock.json" }}
+          key: v1-deps-{{ checksum "yarn.lock" }}
       - run: yarn
       - save_cache:
-          key: v1-deps-{{ checksum "package-lock.json" }}
+          key: v1-deps-{{ checksum "yarn.lock" }}
           paths: 
             - node_modules  
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     docker:
       - image: 'cimg/base:stable'
     steps:
+      - checkout
       - >-
         curl -Ls
         https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: |
             curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci &&
             chmod 755 ./mbx-ci
-            export export MBX_CI_DOMAIN=o619qyc20d.execute-api.us-east-1.amazonaws.com
+            export MBX_CI_DOMAIN=o619qyc20d.execute-api.us-east-1.amazonaws.com
             export GITHUB_TOKEN=$(./mbx-ci github reader token)
             yarn test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-        key: v1-deps-{{ checksum "package-lock.json" }}
+          key: v1-deps-{{ checksum "package-lock.json" }}
       - run: yarn
       - save_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,9 @@
 version: 2.1
-orbs:
-  node: circleci/node@5.0.3
 
 jobs:
   build_and_test:
     docker:
-      - image: 'cimg/base:stable'
+      - image: circleci/node:10
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ jobs:
         https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64
         > mbx-ci && chmod 755 ./mbx-ci
       - run:
-        name: Authenticate mbx-ci and run tests
-        command: |
-          export GITHUB_TOKEN=$(./mbx-ci github reader token)
-          yarn test
+          name: Authenticate mbx-ci and run tests
+          command: |
+            export GITHUB_TOKEN=$(./mbx-ci github reader token)
+            yarn test
 workflows:
   run-npm-command:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
 version: 2.1
+orbs:
+  node: circleci/node@5.0.3
 
 jobs:
   build_and_test:
     docker:
-      - image: cimg/node:9.0.0
+      - image: 'cimg/base:stable'
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
       - run:
           name: Authenticate mbx-ci and run tests
           command: |
-          export GITHUB_TOKEN=$(./mbx-ci github reader token)
-          yarn test
+            export GITHUB_TOKEN=$(./mbx-ci github reader token)
+            yarn test
 
 workflows:
   test_github_release_tools:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,10 @@ jobs:
           paths: 
             - ~/.cache/yarn
       - run:
-          name: Install mbx-ci
+          name: Authenticate mbx-ci and run tests
           command: |
             curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci &&
             chmod 755 ./mbx-ci
-      - run:
-          name: Authenticate mbx-ci and run tests
-          command: |
             export GITHUB_TOKEN=$(./mbx-ci github reader token)
             yarn test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,20 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
-jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
-    steps:
-      - checkout
-      - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+orbs:
+  node: circleci/node@5.0.3
 
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+jobs:
+  build:
+    steps:
+      - curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
+      - run:
+        name: Authenticate mbx-ci and run tests
+        command: |
+          export GITHUB_TOKEN=$(./mbx-ci github reader token)
+          yarn test
+
 workflows:
-  say-hello-workflow:
+  run-npm-command:
     jobs:
-      - say-hello
+      - node/run:
+        yarn-run: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "9"
-cache: yarn


### PR DESCRIPTION
This PR removes travis and migrates github-release-tools to circleci. Next PR will fix broken tests